### PR TITLE
Adding Derpybot.py crash prevention

### DIFF
--- a/derpybot.py
+++ b/derpybot.py
@@ -127,6 +127,23 @@ def shutdown():
 
 stats_module_load()
 common.console_print("DerpyBot version " + version, console_prefix)
+
+#These try commands check if config files are present, because if \config\config.cfg file is not present program will crash.
+try:
+    fh = open(script_location + '/config/config.cfg', 'r')
+    # check to see if config exists
+except FileNotFoundError:
+	common.console_print("'\config\config.cfg' not found!!! Shutting down...")
+	exit()
+    # Inform user config does not exist, then stops the program
+	
+try:
+    fh = open(script_location + '\modules\derpymarkov\config\config.cfg', 'r')
+    # check to see if config exists
+except FileNotFoundError:
+	common.console_print("'\modules\derpymarkov\config\config.cfg' not found. Program will still function but that might cause problems!")
+    # Inform user config does not exist
+
 markov_load(False)
 client_load(False)
 


### PR DESCRIPTION
I had a crash when updating to 0.9.3.7 because I forgot to add the '\config\config.cfg' file. This piece of code should stop the program before it happens and tell the user why the program is stopped. 

The second try code does not stop the program because if '\modules\derpymarkov\config\config.cfg' is not present the program will not crash, instead it wont load any known text files it seems. It will simply inform the user something is not right.